### PR TITLE
Add more tests?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,5 @@ tags
 elm.js
 bundle.*
 *.log
-tests/.gitignore
 tests/Doc/
-tests/*elm
-tests/elm-package.json
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,36 @@
+sudo: false
 language: node_js
-node_js:
-  - "6"
-before_script:
-  - npm install -g elm elm-test elm-doc-test
-  - elm-test init
-  - elm-doc-test
-script: elm-test tests/Doc/Main.elm
+node_js: "node"
+os: linux
+env: ELM_VERSION=0.18.0
+
+cache:
+  directories:
+    - test/elm-stuff/build-artifacts
+    - sysconfcpus
+
+  before_install:
+    - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+    - | # epic build time improvement - see https://github.com/elm-lang/elm-compiler/issues/1473#issuecomment-245704142
+      if [ ! -d sysconfcpus/bin ];
+      then
+      git clone https://github.com/obmarg/libsysconfcpus.git;
+      cd libsysconfcpus;
+      ./configure --prefix=$TRAVIS_BUILD_DIR/sysconfcpus;
+      make && make install;
+      cd ..;
+      fi
+
+  install:
+    - node --version
+    - npm --version
+    - cd tests
+    - npm install -g elm@$ELM_VERSION
+    - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
+    - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
+    - chmod +x $(npm config get prefix)/bin/elm-make
+    - npm install
+    - elm package install --yes
+
+  script:
+    - npm test

--- a/package.json
+++ b/package.json
@@ -6,11 +6,10 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "elm-doc-test && elm-test init && elm-test tests/Doc/Main.elm"
+    "test": "elm-test"
   },
   "devDependencies": {
     "elm": "^0.18.0",
-    "elm-doc-test": "^2.2.3",
     "elm-test": "^0.18.2"
   }
 }

--- a/src/Csv.elm
+++ b/src/Csv.elm
@@ -3,18 +3,23 @@ module Csv exposing (Csv, parse, parseWith, split, splitWith)
 {-| A CSV parser that supports different separators, and quoted fields.
 The results are provided as lists.
 
+
 ## Definitions
+
 @docs Csv
 
+
 ## Parsing functions
+
 @docs parseWith, parse, split, splitWith
+
 -}
 
 import List
 import String
 import Maybe
-
 import Helper exposing (..)
+
 
 {-| The `Csv` type structure.
 -}
@@ -25,36 +30,6 @@ type alias Csv =
 
 
 {-| Convert a string of comma-separated values into a `Csv` structure.
-
-    >>> parse "id,value\n1,one\n2,two\n"
-    {
-      headers = ["id", "value"],
-      records = [
-                    ["1", "one"],
-                    ["2", "two"]
-                ]
-    }
-
-Values that contain the character ',' can be quoted
-
-    >>> parse "id,value\n\"1,2,3\",\"one,two,three\"\n"
-    {
-      headers = ["id", "value"],
-      records = [
-                    ["1,2,3", "one,two,three"]
-                ]
-    }
-
-Double quotes can be escaped with a backslash or a second quote
-
-    >>> parse "value\n,Here is a quote:\"\"\nAnother one:\\\"\n"
-    {
-      headers = ["value"],
-      records = [
-                    ["Here is a quote:\""],
-                    ["Another one:\""]
-                ]
-    }
 -}
 parse : String -> Csv
 parse =
@@ -62,15 +37,6 @@ parse =
 
 
 {-| Convert a string of values separated by a *separator* into a `Csv` structure.
-
-    >>> parseWith ";" "id;value\n1;one\n2;two\n"
-    {
-      headers = ["id", "value"],
-      records = [
-                    ["1", "one"],
-                    ["2", "two"]
-                ]
-    }
 -}
 parseWith : String -> String -> Csv
 parseWith separator lines =
@@ -91,9 +57,6 @@ parseWith separator lines =
 
 
 {-| Convert a string of comma-separated values into a list of lists.
-
-    >>> split "id,value\n1,one\n2,two\n"
-    [["id", "value"], ["1", "one"], ["2", "two"]]
 -}
 split : String -> List (List String)
 split =
@@ -101,9 +64,6 @@ split =
 
 
 {-| Convert a string of values separated by a character into a list of lists.
-
-    >>> splitWith "," "id,value\n1,one\n2,two\n"
-    [["id", "value"], ["1", "one"], ["2", "two"]]
 -}
 splitWith : String -> String -> List (List String)
 splitWith separator lines =
@@ -113,5 +73,3 @@ splitWith separator lines =
                 |> List.filter (\x -> not (String.isEmpty x))
     in
         List.map (splitLineWith separator) values
-
-

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -50,12 +50,6 @@ suite =
         , describe "Line terminators"
             [ test "NL only" <|
                 \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\nd,e,f\ng,h,i\n")
-            , test "CR only" <|
-                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\x0Dg,h,i\x0D")
-            , test "CR only 2" <|
-                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\x0D\nd,e,f\x0D\ng,h,i\x0D\n")
-            , test "Mixed" <|
-                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\ng,h,i\x0D\n")
             ]
         , describe "Row parsing"
             [ test "Empty headers" <|

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -9,12 +9,26 @@ import Debug exposing (log, crash)
 
 suite : Test
 suite =
-    describe "CSV Parser"
-        [ describe "Basic"
-            [ test "Csv.parse" <|
-                \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1", "one" ], [ "2", "two" ] ] } (Csv.parse "id,value\n,1,one\n,2,two\n")
-            , test "Csv.parseWith" <|
+    describe "CSV"
+        [ describe "Csv.parse"
+            [ test "Convert a string of comma-separated values into a `Csv` structure." <|
+                \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1", "one" ], [ "2", "two" ] ] } (Csv.parse "id,value\n1,one\n2,two\n")
+            , test "Values that contain the character ',' can be quoted" <|
+                \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1,2,3", "one,two,three" ] ] } (Csv.parse "id,value\n\"1,2,3\",\"one,two,three\"\n")
+            , test "Double quotes can be escaped with a backslash or a second quote" <|
+                \_ -> Expect.equal { headers = [ "value" ], records = [ [ "Here is a quote:\"" ], [ "Another one:\"" ] ] } (Csv.parse "value\n,Here is a quote:\"\"\nAnother one:\\\"\n")
+            ]
+        , describe "Csv.parseWith"
+            [ test "Convert a string of values separated by a *separator* into a `Csv` structure." <|
                 \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1", "one" ], [ "2", "two" ] ] } (Csv.parseWith ";" "id;value\n;1;one\n;2;two\n")
+            ]
+        , describe "Csv.split"
+            [ test "Convert a string of comma-separated values into a list of lists." <|
+                \_ -> Expect.equal [ [ "id", "value" ], [ "1", "one" ], [ "2", "two" ] ] (Csv.split "id,value\n1,one\n2,two\n")
+            ]
+        , describe "Csv.splitWith"
+            [ test "Convert a string of values separated by a character into a list of lists." <|
+                \_ -> Expect.equal [ [ "id", "value" ], [ "1", "one" ], [ "2", "two" ] ] (Csv.splitWith "," "id,value\n1,one\n2,two\n")
             ]
         , describe "Value parsing"
             [ test "Empty input" <|
@@ -39,7 +53,7 @@ suite =
                 \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\nd,e,f\ng,h,i\n")
             , test "CR only" <|
                 \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\x0Dg,h,i\x0D")
-            , test "CR only" <|
+            , test "CR only 2" <|
                 \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\x0D\nd,e,f\x0D\ng,h,i\x0D\n")
             , test "Mixed" <|
                 \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\ng,h,i\x0D\n")

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -4,7 +4,6 @@ import Expect exposing (Expectation)
 import Fuzz exposing (Fuzzer, int, list, string)
 import Test exposing (..)
 import Csv exposing (..)
-import Debug exposing (log, crash)
 
 
 suite : Test

--- a/tests/Main.elm
+++ b/tests/Main.elm
@@ -1,0 +1,55 @@
+module Main exposing (..)
+
+import Expect exposing (Expectation)
+import Fuzz exposing (Fuzzer, int, list, string)
+import Test exposing (..)
+import Csv exposing (..)
+import Debug exposing (log, crash)
+
+
+suite : Test
+suite =
+    describe "CSV Parser"
+        [ describe "Basic"
+            [ test "Csv.parse" <|
+                \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1", "one" ], [ "2", "two" ] ] } (Csv.parse "id,value\n,1,one\n,2,two\n")
+            , test "Csv.parseWith" <|
+                \_ -> Expect.equal { headers = [ "id", "value" ], records = [ [ "1", "one" ], [ "2", "two" ] ] } (Csv.parseWith ";" "id;value\n;1;one\n;2;two\n")
+            ]
+        , describe "Value parsing"
+            [ test "Empty input" <|
+                \_ -> Expect.equal { headers = [], records = [] } (Csv.parse "")
+            , test "Simple values" <|
+                \_ -> Expect.equal { headers = [ "a", "1" ], records = [] } (Csv.parse "a,1")
+            , test "Special characters" <|
+                \_ -> Expect.equal { headers = [ "< £200", "Allieds" ], records = [] } (Csv.parse "< £200,Allieds")
+            , test "Empty value" <|
+                \_ -> Expect.equal { headers = [ "a", "", "1" ], records = [] } (Csv.parse "a,,1")
+            , test "Preserves spaces" <|
+                \_ -> Expect.equal { headers = [ "a ", "  ", " 1" ], records = [] } (Csv.parse "a ,  , 1")
+            , test "Quoted newlines" <|
+                \_ -> Expect.equal { headers = [ "a", "\nb\n", "c" ], records = [] } (Csv.parse "a,\"\nb\n\",c")
+            , test "Quoted quotes" <|
+                \_ -> Expect.equal { headers = [ "a", "\"", "c" ], records = [] } (Csv.parse "a,\"\"\"\",c")
+            , test "Quoted commas" <|
+                \_ -> Expect.equal { headers = [ "a", "b,b", "c" ], records = [] } (Csv.parse "a,\"b,b\",c")
+            ]
+        , describe "Line terminators"
+            [ test "NL only" <|
+                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\nd,e,f\ng,h,i\n")
+            , test "CR only" <|
+                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\x0Dg,h,i\x0D")
+            , test "CR only" <|
+                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,c\x0D\nd,e,f\x0D\ng,h,i\x0D\n")
+            , test "Mixed" <|
+                \_ -> Expect.equal { headers = [ "a", "b", "c" ], records = [ [ "d", "e", "f" ], [ "g", "h", "i" ] ] } (Csv.parse "a,b,cÝ,e,f\ng,h,i\x0D\n")
+            ]
+        , describe "Row parsing"
+            [ test "Empty headers" <|
+                \_ -> Expect.equal { headers = [ "" ], records = [] } (Csv.parse "\n")
+            , test "Empty headers, empty row" <|
+                \_ -> Expect.equal { headers = [ "" ], records = [ [ "" ] ] } (Csv.parse "\n\n")
+            , test "Trailing newline" <|
+                \_ -> Expect.equal { headers = [ "a" ], records = [ [ "b" ] ] } (Csv.parse "a\nb\n")
+            ]
+        ]

--- a/tests/elm-doc-test.json
+++ b/tests/elm-doc-test.json
@@ -1,7 +1,0 @@
-{
-  "root": "../src",
-  "tests": [
-    "Csv",
-    "Helper"
-  ]
-}

--- a/tests/elm-package.json
+++ b/tests/elm-package.json
@@ -1,0 +1,16 @@
+{
+    "version": "1.0.0",
+    "summary": "Test Suites",
+    "repository": "https://github.com/lovasoa/elm-csv.git",
+    "license": "MIT",
+    "source-directories": [
+        "../src",
+        "."
+    ],
+    "exposed-modules": [],
+    "dependencies": {
+        "elm-lang/core": "5.1.1 <= v < 6.0.0",
+        "elm-community/elm-test": "4.0.0 <= v < 5.0.0"
+    },
+    "elm-version": "0.18.0 <= v < 0.19.0"
+}


### PR DESCRIPTION
I think there is something to be gained by consolidating tests into a test file and incorporating tests from other implementations of CSV parsing in elm. I was having trouble with **elm-doc-test** not producing proper **elm-test** tests

Looking at @periodic 's [elm-csv](https://github.com/periodic/elm-csv) they have test that account for empty inputs, more complex quote scenarios, and more complex line terminating scenarios. 

I moved tests from comments to `tests/Main.elm` and added tests from @periodic 's [elm-csv](https://github.com/periodic/elm-csv). Here is the current output of elm-test. 

```
Success! Compiled 1 module.
Successfully generated /dev/null
Success! Compiled 2 modules.
Successfully generated /home/travis/Documents/elm-csv/elm-stuff/generated-code/elm-community/elm-test/elmTestOutput.js

elm-test 0.18.12
----------------

Running 21 tests. To reproduce these results, run: elm-test --fuzz 100 --seed 1284411382

↓ Main
↓ CSV
↓ Value parsing
✗ Quoted newlines

                                     ▼▼▼▼ ▼▼▼▼▼▼▼▼  
    { headers = ["a",""], records = [["b"],[",c"]] }
    ╷
    │ Expect.equal
    ╵
    { headers = ["a","\nb\n","c"], records = [] }
                      ▲▲▲▲▲ ▲▲▲▲                 


↓ Main
↓ CSV
↓ Value parsing
✗ Quoted quotes

                        ▼ ▼                     
    { headers = ["a","\"\"","c"], records = [] }
    ╷
    │ Expect.equal
    ╵
    { headers = ["a","\"","c"], records = [] }
                                              


↓ Main
↓ CSV
↓ Line terminators
✗ CR only

                           ▼ ▼▼▼▼▼▼▼▼                              
    { headers = ["a","b","cÝ","e","f"], records = [["g","h","i"]] }
    ╷
    │ Expect.equal
    ╵
    { headers = ["a","b","c"], records = [["d","e","f"],["g","h","i"]] }
                                            ▲▲▲▲▲▲▲▲▲▲▲▲▲▲              


↓ Main
↓ CSV
↓ Line terminators
✗ Mixed

                           ▼ ▼▼▼▼▼▼▼▼                              
    { headers = ["a","b","cÝ","e","f"], records = [["g","h","i"]] }
    ╷
    │ Expect.equal
    ╵
    { headers = ["a","b","c"], records = [["d","e","f"],["g","h","i"]] }
                                            ▲▲▲▲▲▲▲▲▲▲▲▲▲▲              


↓ Main
↓ CSV
↓ Row parsing
✗ Empty headers

                                  
    { headers = [], records = [] }
    ╷
    │ Expect.equal
    ╵
    { headers = [""], records = [] }
                 ▲▲                 


↓ Main
↓ CSV
↓ Row parsing
✗ Empty headers, empty row

                                  
    { headers = [], records = [] }
    ╷
    │ Expect.equal
    ╵
    { headers = [""], records = [[""]] }
                 ▲▲              ▲▲▲ ▲  



TEST RUN FAILED

Duration: 159 ms
Passed:   15
Failed:   6


```